### PR TITLE
Recover corrupted settings from the atomic backup

### DIFF
--- a/Guard.Core/Storage/SafeFileWriter.cs
+++ b/Guard.Core/Storage/SafeFileWriter.cs
@@ -14,6 +14,7 @@ namespace Guard.Core.Storage
         /// <param name="content">The byte array content to write.</param>
         public static async Task SaveFileAsync(string targetFilePath, byte[] content)
         {
+            targetFilePath = ValidateTargetFilePath(targetFilePath);
             var fileLock = _fileLocks.GetOrAdd(targetFilePath, _ => new SemaphoreSlim(1, 1));
 
             await fileLock.WaitAsync();
@@ -29,6 +30,7 @@ namespace Guard.Core.Storage
 
         internal static void RestoreFile(string targetFilePath, byte[] content)
         {
+            targetFilePath = ValidateTargetFilePath(targetFilePath);
             var fileLock = _fileLocks.GetOrAdd(targetFilePath, _ => new SemaphoreSlim(1, 1));
 
             fileLock.Wait();
@@ -67,9 +69,10 @@ namespace Guard.Core.Storage
 
         private static async Task SaveFileAsyncInternal(string targetFilePath, byte[] content)
         {
+            targetFilePath = ValidateTargetFilePath(targetFilePath);
             string tempFilePath = GetTempFilePath(targetFilePath);
 
-            string backupFilePath = $"{targetFilePath}.bak";
+            string backupFilePath = ValidateTargetFilePath($"{targetFilePath}.bak");
 
             try
             {
@@ -107,6 +110,7 @@ namespace Guard.Core.Storage
 
         private static string GetTempFilePath(string targetFilePath)
         {
+            targetFilePath = ValidateTargetFilePath(targetFilePath);
             string directory =
                 Path.GetDirectoryName(targetFilePath)
                 ?? throw new ArgumentException("Invalid file path");
@@ -119,6 +123,8 @@ namespace Guard.Core.Storage
             string targetFilePath
         )
         {
+            tempFilePath = ValidateTargetFilePath(tempFilePath);
+            targetFilePath = ValidateTargetFilePath(targetFilePath);
             if (!File.Exists(targetFilePath))
             {
                 File.Move(tempFilePath, targetFilePath);
@@ -138,10 +144,41 @@ namespace Guard.Core.Storage
 
         private static void DeleteIfExists(string path)
         {
+            path = ValidateTargetFilePath(path);
             if (File.Exists(path))
             {
                 File.Delete(path);
             }
+        }
+
+        private static string ValidateTargetFilePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || path.Contains("..", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("Invalid file path");
+            }
+
+            string appDataDirectory = Path.GetFullPath(
+                InstallationContext.GetAppDataFolderPath()
+            );
+            string fullPath = Path.GetFullPath(path);
+            string relativePath = Path.GetRelativePath(appDataDirectory, fullPath);
+            if (
+                Path.IsPathRooted(relativePath)
+                || relativePath.Equals("..", StringComparison.Ordinal)
+                || relativePath.StartsWith(
+                    $"..{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal
+                )
+                || relativePath.StartsWith(
+                    $"..{Path.AltDirectorySeparatorChar}",
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                throw new ArgumentException("File path must be inside the application data folder");
+            }
+            return fullPath;
         }
     }
 }

--- a/Guard.Core/Storage/SafeFileWriter.cs
+++ b/Guard.Core/Storage/SafeFileWriter.cs
@@ -27,43 +27,116 @@ namespace Guard.Core.Storage
             }
         }
 
+        internal static void RestoreFile(string targetFilePath, byte[] content)
+        {
+            var fileLock = _fileLocks.GetOrAdd(targetFilePath, _ => new SemaphoreSlim(1, 1));
+
+            fileLock.Wait();
+            try
+            {
+                string tempFilePath = GetTempFilePath(targetFilePath);
+                try
+                {
+                    using FileStream stream = new(
+                        tempFilePath,
+                        FileMode.CreateNew,
+                        FileAccess.Write,
+                        FileShare.None,
+                        4096,
+                        FileOptions.WriteThrough
+                    );
+                    stream.Write(content);
+                    stream.Flush(true);
+                    ReplaceWithoutOverwritingBackup(tempFilePath, targetFilePath);
+                }
+                catch
+                {
+                    DeleteIfExists(tempFilePath);
+                    throw;
+                }
+            }
+            finally
+            {
+                fileLock.Release();
+            }
+        }
+
         private static async Task SaveFileAsyncInternal(string targetFilePath, byte[] content)
         {
-            string directory =
-                Path.GetDirectoryName(targetFilePath)
-                ?? throw new ArgumentException("Invalid file path");
-            string fileName = Path.GetFileName(targetFilePath);
+            string tempFilePath = GetTempFilePath(targetFilePath);
 
-            string randomPart = Guid.NewGuid().ToString("N");
-            string tempFileName = $"{fileName}.{randomPart}.tmp";
-            string tempFilePath = Path.Combine(directory, tempFileName);
-
-            string backupFilePath = Path.Combine(directory, $"{fileName}.bak");
+            string backupFilePath = $"{targetFilePath}.bak";
 
             try
             {
-                // Write to temp file asynchronously
-                await File.WriteAllBytesAsync(tempFilePath, content);
+                await using (
+                    FileStream stream = new(
+                        tempFilePath,
+                        FileMode.CreateNew,
+                        FileAccess.Write,
+                        FileShare.None,
+                        4096,
+                        FileOptions.Asynchronous | FileOptions.WriteThrough
+                    )
+                )
+                {
+                    await stream.WriteAsync(content);
+                    await stream.FlushAsync();
+                    stream.Flush(true);
+                }
 
                 if (File.Exists(targetFilePath))
                 {
-                    // Replace original file atomically and create backup with .bak extension
                     File.Replace(tempFilePath, targetFilePath, backupFilePath);
                 }
                 else
                 {
-                    // No original file, just move temp to target
                     File.Move(tempFilePath, targetFilePath);
                 }
             }
             catch
             {
-                // Clean up temp file if something went wrong
-                if (File.Exists(tempFilePath))
-                {
-                    File.Delete(tempFilePath);
-                }
+                DeleteIfExists(tempFilePath);
                 throw;
+            }
+        }
+
+        private static string GetTempFilePath(string targetFilePath)
+        {
+            string directory =
+                Path.GetDirectoryName(targetFilePath)
+                ?? throw new ArgumentException("Invalid file path");
+            string fileName = Path.GetFileName(targetFilePath);
+            return Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}.tmp");
+        }
+
+        private static void ReplaceWithoutOverwritingBackup(
+            string tempFilePath,
+            string targetFilePath
+        )
+        {
+            if (!File.Exists(targetFilePath))
+            {
+                File.Move(tempFilePath, targetFilePath);
+                return;
+            }
+
+            string displacedFilePath = GetTempFilePath(targetFilePath);
+            try
+            {
+                File.Replace(tempFilePath, targetFilePath, displacedFilePath);
+            }
+            finally
+            {
+                DeleteIfExists(displacedFilePath);
+            }
+        }
+
+        private static void DeleteIfExists(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
             }
         }
     }

--- a/Guard.Core/Storage/SafeFileWriter.cs
+++ b/Guard.Core/Storage/SafeFileWriter.cs
@@ -37,16 +37,20 @@ namespace Guard.Core.Storage
                 string tempFilePath = GetTempFilePath(targetFilePath);
                 try
                 {
-                    using FileStream stream = new(
-                        tempFilePath,
-                        FileMode.CreateNew,
-                        FileAccess.Write,
-                        FileShare.None,
-                        4096,
-                        FileOptions.WriteThrough
-                    );
-                    stream.Write(content);
-                    stream.Flush(true);
+                    using (
+                        FileStream stream = new(
+                            tempFilePath,
+                            FileMode.CreateNew,
+                            FileAccess.Write,
+                            FileShare.None,
+                            4096,
+                            FileOptions.WriteThrough
+                        )
+                    )
+                    {
+                        stream.Write(content);
+                        stream.Flush(true);
+                    }
                     ReplaceWithoutOverwritingBackup(tempFilePath, targetFilePath);
                 }
                 catch

--- a/Guard.Core/Storage/SettingsManager.cs
+++ b/Guard.Core/Storage/SettingsManager.cs
@@ -14,16 +14,47 @@ namespace Guard.Core.Storage
 
         public static void Init()
         {
-            if (File.Exists(settingsFilePath))
+            string backupFilePath = $"{settingsFilePath}.bak";
+            if (!File.Exists(settingsFilePath))
             {
-                byte[] fileData = File.ReadAllBytes(settingsFilePath);
-                string fileContent = System.Text.Encoding.UTF8.GetString(fileData);
-                AppSettings? appSettings = JsonSerializer.Deserialize<AppSettings>(fileContent);
-                if (appSettings != null)
+                Settings = File.Exists(backupFilePath)
+                    ? RestoreBackup(settingsFilePath, backupFilePath)
+                    : new();
+                return;
+            }
+
+            try
+            {
+                Settings = ReadSettings(settingsFilePath);
+            }
+            catch (JsonException primaryException) when (File.Exists(backupFilePath))
+            {
+                try
                 {
-                    Settings = appSettings;
+                    Settings = RestoreBackup(settingsFilePath, backupFilePath);
+                }
+                catch (JsonException backupException)
+                {
+                    throw new JsonException(
+                        "Both the primary settings file and its backup are invalid.",
+                        new AggregateException(primaryException, backupException)
+                    );
                 }
             }
+        }
+
+        private static AppSettings ReadSettings(string filePath)
+        {
+            byte[] fileData = File.ReadAllBytes(filePath);
+            AppSettings? appSettings = JsonSerializer.Deserialize<AppSettings>(fileData);
+            return appSettings ?? throw new JsonException("The settings file contains null.");
+        }
+
+        private static AppSettings RestoreBackup(string filePath, string backupFilePath)
+        {
+            AppSettings appSettings = ReadSettings(backupFilePath);
+            SafeFileWriter.RestoreFile(filePath, File.ReadAllBytes(backupFilePath));
+            return appSettings;
         }
 
         public static async Task Save()

--- a/Guard.Test/Core/SettingsManager.cs
+++ b/Guard.Test/Core/SettingsManager.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Guard.Core.Models;
+using Guard.Core.Storage;
+
+namespace Guard.Test.Core
+{
+    public class SettingsManagerTests : IDisposable
+    {
+        private readonly string testDirectory;
+        private readonly string settingsPath;
+        private readonly byte[]? originalSettings;
+        private readonly byte[]? originalBackup;
+
+        public SettingsManagerTests()
+        {
+            InstallationContext.Init(InstallationType.CLASSIC_PORTABLE, new Version(1, 0));
+            testDirectory = InstallationContext.GetAppDataFolderPath();
+            settingsPath = Path.Combine(testDirectory, "settings");
+            originalSettings = File.Exists(settingsPath) ? File.ReadAllBytes(settingsPath) : null;
+            originalBackup = File.Exists($"{settingsPath}.bak")
+                ? File.ReadAllBytes($"{settingsPath}.bak")
+                : null;
+            Directory.CreateDirectory(testDirectory);
+        }
+
+        [Fact]
+        public void RecoversCorruptedSettingsFromBackup()
+        {
+            string backupPath = $"{settingsPath}.bak";
+            AppSettings expected = new()
+            {
+                Theme = ThemeSetting.Dark,
+                Language = LanguageSetting.DE,
+                MinimizeToTray = true,
+            };
+            string backupContent = JsonSerializer.Serialize(expected);
+
+            File.WriteAllBytes(settingsPath, new byte[4096]);
+            File.WriteAllText(backupPath, backupContent);
+
+            Guard.Core.Storage.SettingsManager.Init();
+            AppSettings actual = Guard.Core.Storage.SettingsManager.Settings;
+
+            Assert.Equal(expected.Theme, actual.Theme);
+            Assert.Equal(expected.Language, actual.Language);
+            Assert.Equal(expected.MinimizeToTray, actual.MinimizeToTray);
+            Assert.Equal(backupContent, File.ReadAllText(settingsPath));
+            Assert.Equal(backupContent, File.ReadAllText(backupPath));
+        }
+
+        [Fact]
+        public void ThrowsWhenSettingsAndBackupAreBothCorrupted()
+        {
+            File.WriteAllBytes(settingsPath, new byte[4096]);
+            File.WriteAllText($"{settingsPath}.bak", "not-json");
+
+            Assert.Throws<JsonException>(() =>
+                Guard.Core.Storage.SettingsManager.Init()
+            );
+        }
+
+        public void Dispose()
+        {
+            RestoreFile(settingsPath, originalSettings);
+            RestoreFile($"{settingsPath}.bak", originalBackup);
+            Guard.Core.Storage.SettingsManager.Settings = new();
+            GC.SuppressFinalize(this);
+        }
+
+        private static void RestoreFile(string path, byte[]? content)
+        {
+            if (content == null)
+            {
+                File.Delete(path);
+                return;
+            }
+            File.WriteAllBytes(path, content);
+        }
+    }
+}

--- a/Guard.Test/Core/SettingsManager.cs
+++ b/Guard.Test/Core/SettingsManager.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Guard.Core;
 using Guard.Core.Models;
 using Guard.Core.Storage;
 

--- a/Guard.Test/Core/SettingsManager.cs
+++ b/Guard.Test/Core/SettingsManager.cs
@@ -60,6 +60,17 @@ namespace Guard.Test.Core
             );
         }
 
+        [Fact]
+        public async Task RejectsFileWritesOutsideAppDataFolder()
+        {
+            string outsidePath = Path.Combine(testDirectory, "..", "outside-settings");
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                SafeFileWriter.SaveFileAsync(outsidePath, [1, 2, 3])
+            );
+            Assert.False(File.Exists(Path.GetFullPath(outsidePath)));
+        }
+
         public void Dispose()
         {
             RestoreFile(settingsPath, originalSettings);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix

## Description

2FAGuard currently aborts during startup when the primary `settings` file is truncated or filled with zero bytes, even when the atomic writer left a valid `settings.bak`.

This change:

- falls back to a valid backup when the primary settings file is missing or invalid;
- restores the primary atomically without overwriting the known-good `.bak`;
- keeps startup fail-closed when both files are invalid;
- flushes temporary writes to disk before `File.Replace`, reducing the power-loss window;
- constrains atomic file operations to the initialized 2FAGuard app-data directory.

## Regression coverage

The reproducer writes a 4096-byte all-zero primary settings file and a valid JSON backup. Before the fix, the targeted test fails in `SettingsManager.Init()` with `0x00 is an invalid start of a value`. After the fix:

- full test suite: 41 passed;
- CLI Release build: succeeded;
- WPF Release build: succeeded;
- Aikido Security and CodeFactor checks: passed.

The local Windows verifier used the installed .NET 9 SDK with a temporary TFM compatibility override because .NET 10 was not installed on that machine. The repository’s unchanged Windows/.NET 10 workflow remains the authoritative CI check.

## Additional context

The tests also verify that an invalid primary plus an invalid backup still throws, that successful recovery leaves the valid backup unchanged, and that writes outside app-data are rejected.